### PR TITLE
fix:backup on cloud-init disk and feat: improve scsi disk

### DIFF
--- a/kubernetes/02_kubernetes_production_ready/terraform/locals.tf
+++ b/kubernetes/02_kubernetes_production_ready/terraform/locals.tf
@@ -18,9 +18,11 @@ locals {
       type    = "disk"
       storage = "local-lvm"
       slot    = "scsi0"
+      discard = true
+      cache   = "writeback"
     }
     cloudinit = {
-      backup  = false
+      backup  = true
       format  = "raw"
       type    = "cloudinit"
       storage = "local-lvm"

--- a/kubernetes/02_kubernetes_production_ready/terraform/locals.tf
+++ b/kubernetes/02_kubernetes_production_ready/terraform/locals.tf
@@ -19,7 +19,6 @@ locals {
       storage = "local-lvm"
       slot    = "scsi0"
       discard = true
-      cache   = "writeback"
     }
     cloudinit = {
       backup  = true

--- a/kubernetes/02_kubernetes_production_ready/terraform/masters.tf
+++ b/kubernetes/02_kubernetes_production_ready/terraform/masters.tf
@@ -29,6 +29,7 @@ resource "proxmox_vm_qemu" "masters" {
   )
 
   network {
+    id     = 0
     bridge = local.bridge.interface
     model  = local.bridge.model
   }
@@ -55,6 +56,7 @@ resource "proxmox_vm_qemu" "masters" {
     storage = local.disks.main.storage
     size    = local.masters.disk_size
     slot    = local.disks.main.slot
+    discard = local.disks.main.discard
   }
 
   tags = local.masters.tags

--- a/kubernetes/02_kubernetes_production_ready/terraform/provider.tf
+++ b/kubernetes/02_kubernetes_production_ready/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "3.0.1-rc4"
+      version = "3.0.1-rc6"
     }
     local = {
       source  = "hashicorp/local"

--- a/kubernetes/02_kubernetes_production_ready/terraform/workers.tf
+++ b/kubernetes/02_kubernetes_production_ready/terraform/workers.tf
@@ -29,6 +29,7 @@ resource "proxmox_vm_qemu" "workers" {
   )
 
   network {
+    id     = 0
     bridge = local.bridge.interface
     model  = local.bridge.model
   }
@@ -55,6 +56,7 @@ resource "proxmox_vm_qemu" "workers" {
     storage = local.disks.main.storage
     size    = local.workers.disk_size
     slot    = local.disks.main.slot
+    discard = local.disks.main.discard
   }
 
   tags = local.workers.tags


### PR DESCRIPTION
fix backup on cloud-init disk:
- cloudinit disk doesn't support disable backup

improve SCSI disk:
- add discard to improve backup size by freeing unused blocks